### PR TITLE
add QemuVM Clone method, fix Qemu() parsing

### DIFF
--- a/node.go
+++ b/node.go
@@ -55,7 +55,6 @@ func (node Node) Qemu() (QemuList, error) {
 			Disk:      v["disk"].(float64),
 			MaxMem:    v["maxmem"].(float64),
 			Status:    v["status"].(string),
-			Template:  v["template"].(string),
 			NetIn:     v["netin"].(float64),
 			MaxDisk:   v["maxdisk"].(float64),
 			Name:      v["name"].(string),
@@ -66,6 +65,14 @@ func (node Node) Qemu() (QemuList, error) {
 			Uptime:    v["uptime"].(float64),
 			Node:      node,
 		}
+
+		switch v["template"].(type) {
+		case float64:
+			vm.Template = v["template"].(float64)
+		default:
+			vm.Template = 0
+		}
+
 		list[strconv.FormatFloat(vm.VMId, 'f', 0, 64)] = vm
 	}
 

--- a/proxmox.go
+++ b/proxmox.go
@@ -173,6 +173,15 @@ func (proxmox ProxMox) maxVMId() (float64, error) {
 	return maxId, err
 }
 
+func (proxmox ProxMox) NextVMId() (float64, error) {
+	max, err := proxmox.maxVMId()
+	if err != nil {
+		return max, err
+	}
+
+	return max + 1, nil
+}
+
 func (proxmox ProxMox) DetermineVMPlacement(cpu int64, cores int64, mem int64, overCommitCPU float64, overCommitMem float64) (Node, error) {
 	var nodeList NodeList
 	var node Node

--- a/qemu.go
+++ b/qemu.go
@@ -2,7 +2,7 @@ package proxmox
 
 import (
 	"errors"
-	_ "fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -177,6 +177,7 @@ func (qemu QemuVM) WaitForStatus(status string, timeout int) error {
 		if err != nil {
 			return err
 		}
+
 		if qStatus.Status == status {
 			return nil
 		}
@@ -238,4 +239,28 @@ func (qemu QemuVM) Resume() error {
 	target = "nodes/" + qemu.Node.Node + "/qemu/" + strconv.FormatFloat(qemu.VMId, 'f', 0, 64) + "/status/resume"
 	_, err = qemu.Node.Proxmox.Post(target, "")
 	return err
+}
+
+func (qemu QemuVM) Clone(newId float64, name string, targetName string) (string, error) {
+	var target string
+	var err error
+
+	newVMID := strconv.FormatFloat(newId, 'f', 0, 64)
+
+	target = "nodes/" + qemu.Node.Node + "/qemu/" + strconv.FormatFloat(qemu.VMId, 'f', 0, 64) + "/clone"
+
+	form := url.Values{
+		"newid":  {newVMID},
+		"name":   {name},
+		"target": {targetName},
+	}
+
+	data, err := qemu.Node.Proxmox.PostForm(target, form)
+	if err != err {
+		return "", err
+	}
+
+	UPid := data["data"].(string)
+
+	return UPid, nil
 }

--- a/qemu.go
+++ b/qemu.go
@@ -18,7 +18,7 @@ type QemuVM struct {
 	Disk      float64 `json:"disk"`
 	MaxMem    float64 `json:"maxmem"`
 	Status    string  `json:"status"`
-	Template  string  `json:"template"`
+	Template  float64 `json:"template"`
 	NetIn     float64 `json:"netin"`
 	MaxDisk   float64 `json:"maxdisk"`
 	Name      string  `json:"name"`


### PR DESCRIPTION
Add `Clone(...)` method to `QemuVM` to allow cloning templates.

Fix parsing of `template` variable in `node.Qemu()` method. JSON returned by Proxmox API contains `""` (empty string) if specified VM is not a template, and `1` if it is a template.