### PR TITLE
Qemu Description can be empty & delete fmt.Print Debug login & GoFmt *

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -1,8 +1,8 @@
 package proxmox
 
 type Pool struct {
-	Poolid       string  `json:"poolid"`
-	proxmox    ProxMox
+	Poolid  string `json:"poolid"`
+	proxmox ProxMox
 }
 
 type PoolList map[string]Pool

--- a/proxmox.go
+++ b/proxmox.go
@@ -83,7 +83,7 @@ func NewProxMox(HostName string, UserName string, Password string) (*ProxMox, er
 		return nil, err
 	} else {
 		proxmox.ConnectionTicket = data["ticket"].(string)
-    proxmox.connectionCSRFPreventionToken = data["CSRFPreventionToken"].(string)
+		proxmox.connectionCSRFPreventionToken = data["CSRFPreventionToken"].(string)
 		proxmox.Client.Jar, err = cookiejar.New(nil)
 		domain = proxmox.Hostname
 
@@ -293,7 +293,7 @@ func (proxmox ProxMox) Tasks() (TaskList, error) {
 }
 
 func (proxmox ProxMox) Pools() (PoolList, error) {
-  var err error
+	var err error
 	var target string
 	var data map[string]interface{}
 	var list PoolList
@@ -311,62 +311,62 @@ func (proxmox ProxMox) Pools() (PoolList, error) {
 	for _, v0 := range results {
 		v := v0.(map[string]interface{})
 		pool = Pool{
-			Poolid:    v["poolid"].(string),
+			Poolid:  v["poolid"].(string),
 			proxmox: proxmox,
 		}
 
 		list[pool.Poolid] = pool
-  }
+	}
 
-  return list, nil
+	return list, nil
 }
 
 func (proxmox ProxMox) NewPool(name string, comment string) (map[string]interface{}, error) {
-  poolForm := url.Values{}
-  poolForm.Set("poolid", name)
-  poolForm.Set("comment", comment)
+	poolForm := url.Values{}
+	poolForm.Set("poolid", name)
+	poolForm.Set("comment", comment)
 
-  result, err := proxmox.PostForm("pools", poolForm)
-  if err != nil {
-    fmt.Println("Error while posting form")
-    fmt.Println(err)
-    return result, err
-  }
+	result, err := proxmox.PostForm("pools", poolForm)
+	if err != nil {
+		fmt.Println("Error while posting form")
+		fmt.Println(err)
+		return result, err
+	}
 
-  fmt.Printf("Result: %s", result)
+	fmt.Printf("Result: %s", result)
 
-  return result, nil
+	return result, nil
 }
 
 func (proxmox ProxMox) UpdatePool(name string, comment string) (map[string]interface{}, error) {
-  poolForm := url.Values{}
-  poolForm.Set("poolid", name)
-  poolForm.Set("comment", comment)
+	poolForm := url.Values{}
+	poolForm.Set("poolid", name)
+	poolForm.Set("comment", comment)
 
-  result, err := proxmox.PutForm("pools/" + name, poolForm)
-  if err != nil {
-    fmt.Println("Error while posting form")
-    fmt.Println(err)
-    return result, err
-  }
+	result, err := proxmox.PutForm("pools/"+name, poolForm)
+	if err != nil {
+		fmt.Println("Error while posting form")
+		fmt.Println(err)
+		return result, err
+	}
 
-  fmt.Printf("Result: %s", result)
+	fmt.Printf("Result: %s", result)
 
-  return result, nil
+	return result, nil
 }
 
 func (proxmox ProxMox) DeletePool(name string) error {
-  result, err := proxmox.Delete(fmt.Sprintf("pools/%s", name))
+	result, err := proxmox.Delete(fmt.Sprintf("pools/%s", name))
 
-  if err != nil {
-    fmt.Printf("Error deleting pool: %s", name)
-    fmt.Println(err)
-    fmt.Printf("Result was: %s", result)
-  }
+	if err != nil {
+		fmt.Printf("Error deleting pool: %s", name)
+		fmt.Println(err)
+		fmt.Printf("Result was: %s", result)
+	}
 
-  fmt.Printf("Created pool: %s\n", name)
+	fmt.Printf("Created pool: %s\n", name)
 
-  return nil
+	return nil
 }
 
 func (proxmox ProxMox) PostForm(endpoint string, form url.Values) (map[string]interface{}, error) {
@@ -388,7 +388,7 @@ func (proxmox ProxMox) PostForm(endpoint string, form url.Values) (map[string]in
 		req.Header.Add("CSRFPreventionToken", proxmox.connectionCSRFPreventionToken)
 	}
 
-  fmt.Printf("Posting form values: %s\n", req)
+	//fmt.Printf("Posting form values: %s\n", req)
 
 	r, err := proxmox.Client.Do(req)
 	if err != nil {

--- a/qemu.go
+++ b/qemu.go
@@ -129,7 +129,7 @@ func (qemu QemuVM) Config() (QemuConfig, error) {
 	case float64:
 		config.Sockets = results["sockets"].(float64)
 	}
-	disktype := [3]string{"virtio", "sata", "ide"}
+	disktype := [4]string{"virtio", "sata", "ide", "scsi"}
 	disknum := [4]string{"0", "1", "2", "3"}
 	config.Disks = make(map[string]string)
 	for _, d := range disktype {

--- a/qemu.go
+++ b/qemu.go
@@ -94,6 +94,7 @@ func (qemu QemuVM) Config() (QemuConfig, error) {
 	var results map[string]interface{}
 	var config QemuConfig
 	var err error
+	var description string
 
 	//fmt.Print("!QemuConfig ", qemu.VMId)
 
@@ -103,6 +104,9 @@ func (qemu QemuVM) Config() (QemuConfig, error) {
 	if err != nil {
 		return config, err
 	}
+	if description, _ = results["description"].(string); err != nil {
+		return config, err
+	}
 	config = QemuConfig{
 		Bootdisk:    results["bootdisk"].(string),
 		Cores:       results["cores"].(float64),
@@ -110,7 +114,7 @@ func (qemu QemuVM) Config() (QemuConfig, error) {
 		Memory:      results["memory"].(float64),
 		Sockets:     results["sockets"].(float64),
 		SMBios1:     results["smbios1"].(string),
-		Description: results["description"].(string),
+		Description: description,
 	}
 
 	switch results["cores"].(type) {
@@ -306,14 +310,14 @@ func (qemu QemuVM) CloneToPool(newId float64, name string, targetName string, po
 	return t, nil
 }
 
-func (qemu QemuVM) SetDescription(description string) (error) {
+func (qemu QemuVM) SetDescription(description string) error {
 	var target string
 	var err error
 
 	target = "nodes/" + qemu.Node.Node + "/qemu/" + strconv.FormatFloat(qemu.VMId, 'f', 0, 64) + "/config"
 
 	form := url.Values{
-		"description":  {description},
+		"description": {description},
 	}
 
 	_, err = qemu.Node.Proxmox.PutForm(target, form)
@@ -324,14 +328,14 @@ func (qemu QemuVM) SetDescription(description string) (error) {
 	return nil
 }
 
-func (qemu QemuVM) SetMemory(memory string) (error) {
+func (qemu QemuVM) SetMemory(memory string) error {
 	var target string
 	var err error
 
 	target = "nodes/" + qemu.Node.Node + "/qemu/" + strconv.FormatFloat(qemu.VMId, 'f', 0, 64) + "/config"
 
 	form := url.Values{
-		"memory":  {memory},
+		"memory": {memory},
 	}
 
 	_, err = qemu.Node.Proxmox.PutForm(target, form)


### PR DESCRIPTION
Hi,

3 small modifications : 

- The qemu description can be empty, it fix the bug that if the descrition is empty, the Config() function crash : 

```
panic: interface conversion: interface {} is nil, not string
```

- There was a fmt.Print that print the Login Post information for debug. I commented it. 

- I launched GoFmt on all files. 

Thanks for this Lib !! 