### PR TITLE
fix - panic: interface conversion: interface {} is string, not float64

### DIFF
--- a/node.go
+++ b/node.go
@@ -45,6 +45,10 @@ func (node Node) Qemu() (QemuList, error) {
 	results = data["data"].([]interface{})
 	for _, v0 := range results {
 		v := v0.(map[string]interface{})
+		VMIdFloat, err := strconv.ParseFloat(v["vmid"].(string), 64)
+		if err != nil {
+			return nil, err
+		}
 		vm = QemuVM{
 			Mem:    v["mem"].(float64),
 			CPUs:   v["cpus"].(float64),
@@ -58,7 +62,7 @@ func (node Node) Qemu() (QemuList, error) {
 			Name:      v["name"].(string),
 			DiskWrite: v["diskwrite"].(float64),
 			CPU:       v["cpu"].(float64),
-			VMId:      v["vmid"].(float64),
+			VMId:      VMIdFloat,
 			DiskRead:  v["diskread"].(float64),
 			Uptime:    v["uptime"].(float64),
 			Node:      node,


### PR DESCRIPTION
Hi,

On latest Proxmox releases, VMId is not getting as a float64, so let's ensure it is. 

Thanks ! 